### PR TITLE
add beacon_node_*_light_client_data variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,11 @@ beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
 
+# Light client data
+beacon_node_light_client_data_enabled: false
+beacon_node_light_client_data_serve: false
+beacon_node_light_client_data_import: 'none'
+
 # resource limits, mem in MB
 beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.5) | int }}'
 beacon_node_mem_reserve: '{{ (ansible_memtotal_mb * 0.4) | int }}'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -62,3 +62,7 @@
       {% for pubkey in beacon_node_validator_monitor_pubkeys %}
       --validator-monitor-pubkey={{ pubkey }}
       {% endfor %}
+      {% if beacon_node_light_client_data_enabled %}
+      --serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }}
+      --import-light-client-data={{ beacon_node_light_client_data_import }}
+      {% endif %}


### PR DESCRIPTION
To control the `--serve-light-client-data` and
`--import-light-client-data` flags.

Note: These new flags are only available on `unstable` at this time. `stable` does not support them yet.