### PR TITLE
renamed BN light client data options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ beacon_node_rest_port: 5052
 # Light client data
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
-beacon_node_light_client_data_import: 'none'
+beacon_node_light_client_data_import_mode: 'none'
 
 # resource limits, mem in MB
 beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.5) | int }}'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -62,8 +62,8 @@
       --validator-monitor-pubkey={{ pubkey }}
       {% endfor %}
       {% if beacon_node_light_client_data_enabled %}
-      --serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }}
-      --import-light-client-data={{ beacon_node_light_client_data_import }}
+      --light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }}
+      --light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }}
       {% endif %}
       {% for extra_flag in beacon_node_extra_flags %}
       {{ extra_flag }}


### PR DESCRIPTION
Adjusts for the new names of BN light client data config options
* `--serve-light-client-data` --> `--light-client-data-serve`
* `--import-light-client-data` --> `--light-client-data-import-mode`
