### PR TITLE
add beacon_node_light_client_data_max_periods

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ beacon_node_rest_port: 5052
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
 beacon_node_light_client_data_import_mode: 'none'
+beacon_node_light_client_data_max_periods: -1 # -1 to use default
 
 # resource limits, mem in MB
 beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.5) | int }}'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -64,6 +64,9 @@
       {% if beacon_node_light_client_data_enabled %}
       --light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }}
       --light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }}
+      {% if beacon_node_light_client_data_max_periods >= 0 %}
+      --light-client-data-max-periods={{ beacon_node_light_client_data_max_periods }}
+      {% endif %}
       {% endif %}
       {% for extra_flag in beacon_node_extra_flags %}
       {{ extra_flag }}


### PR DESCRIPTION
Allows overriding `--light-client-data-max-periods` as introduced in
https://github.com/status-im/nimbus-eth2/pull/3799
