### PR TITLE
update LC data defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,8 +71,8 @@ beacon_node_rest_port: 5052
 
 # Light client data
 beacon_node_light_client_data_enabled: false
-beacon_node_light_client_data_serve: false
-beacon_node_light_client_data_import_mode: 'none'
+beacon_node_light_client_data_serve: true
+beacon_node_light_client_data_import_mode: 'only-new'
 beacon_node_light_client_data_max_periods: -1 # -1 to use default
 
 # resource limits, mem in MB


### PR DESCRIPTION
Syncs LC data defaults with `nimbus-eth2` -> `beacon_chain/conf.nim`.
