### PR TITLE
service: apply rest-max-body-size and rest-max-headers-size

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,8 @@ beacon_node_metrics_port: 9200
 beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
+beacon_node_rest_max_body_size: 16384
+beacon_node_rest_max_headers_size: 128
 
 # Light client data
 beacon_node_light_client_data_enabled: false

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -49,6 +49,8 @@
       {% if beacon_node_rest_enabled %}
       --rest-address={{ beacon_node_rest_address }}
       --rest-port={{ beacon_node_rest_port }}
+      --rest-max-body-size={{ beacon_node_rest_max_body_size | mandatory }}
+      --rest-max-headers-size={{ beacon_node_rest_max_headers_size | mandatory }}
       {% endif %}
       --metrics={{ beacon_node_metrics_enabled | to_json }}
       {% if beacon_node_metrics_enabled %}


### PR DESCRIPTION
Those two options are applied in `infra-role-beacon-node-linux`; do the same for Windows.